### PR TITLE
Clean up the docs a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,8 @@ Untitled*.*
 *~
 *.orig
 probfit/*.html
+.project
+.pydevproject
+.settings
 
 !/tutorial/*.ipynb

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ branches:
 python:
   - "2.6"
   - "2.7"
+
 # command to install dependencies
 install:
     - "pip install matplotlib --use-mirrors"
-    - "git clone git://github.com/piti118/iminuit.git; cd iminuit; python setup.py install; cd .."
+    - "git clone git://github.com/iminuit/iminuit.git; cd iminuit; python setup.py install; cd .."
+
 # command to run tests
 script:
     - "python setup.py build_ext -i"

--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,10 @@
 
 
 probfit
---------
+-------
 
 *probfit* is a set of functions that helps you construct a complex fit. It's
-intended to be used with `iminuit <http://iminuit.github.com/iminuit/>`_. The
+intended to be used with `iminuit <http://iminuit.github.io/iminuit/>`_. The
 tool includes Binned/Unbinned Likelihood estimator, :math:`\chi^2` regression,
 Binned :math:`\chi^2` estimator and Simultaneous fit estimator.
 Various functors for manipulating PDF such as Normalization and
@@ -17,29 +17,22 @@ normally used in B physics is also provided.
 
 ::
 
-    from probfit import UnbinnedLH, gaussian
+    import numpy as np
     from iminuit import Minuit
-    data = np.randn(10000)
-    ulh = UnbinnedLH(data)
-    m = Minuit(ulh, mean=0.1, sigma=1.1)
-    m.migrad()
-    ulh.draw(m)
+    from probfit import UnbinnedLH, gaussian
+    data = np.random.randn(10000)
+    unbinned_likelihood = UnbinnedLH(gaussian, data)
+    fitter = Minuit(unbinned_likelihood, mean=0.1, sigma=1.1)
+    fitter.migrad()
+    unbinned_likelihood.draw(fitter)
 
 
-Requirement
------------
-
-- iminuit http://iminuit.github.com/iminuit/
-- numpy http://www.numpy.org/
-- matplotlib http://matplotlib.org/
-
-Tutorial
---------
-
-open tutorial.ipynb in ipython notebook. You can `view it online <http://nbviewer.ipython.org/urls/raw.github.com/iminuit/probfit/master/tutorial/tutorial.ipynb>`_ too.
-
-
-Documentation
--------------
-
-See `here <http://iminuit.github.com/probfit/>`_
+* `MIT <http://opensource.org/licenses/MIT>`_ license (open source)
+* `Documentation <http://iminuit.github.io/probfit/>`_
+* The tutorial is an IPython notebook that you can view online
+  `here <http://nbviewer.ipython.org/urls/raw.github.com/iminuit/probfit/master/tutorial/tutorial.ipynb>`_.
+  To run it locally: `cd tutorial; ipython notebook --pylab=inline tutorial.ipynb`.
+* Dependencies:
+   - `iminuit <http://iminuit.github.io/iminuit/>`_
+   - `numpy <http://www.numpy.org/>`_
+   - `matplotlib <http://matplotlib.org/>`_ (optional, for plotting)

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -118,7 +118,7 @@ AddPdf
         :class: lightbox
 
 AddPdfNorm
-^^^^^^^^^^^
+^^^^^^^^^^
 .. autoclass:: AddPdfNorm
 
 **Example**
@@ -132,7 +132,7 @@ rename
 .. autofunction:: probfit.funcutil.rename
 
 Decorator
-^^^^^^^^^^
+^^^^^^^^^
 .. currentmodule:: probfit.decorator
 
 .. autoclass:: normalized

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -73,7 +73,7 @@ release = probfit.info.__version__
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', '_themes']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None
@@ -130,7 +130,7 @@ html_theme_path = ['_themes', ]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,16 +2,27 @@ probfit
 =======
 
 *probfit* is a set of functions that helps you construct a complex fit. It's
-intended to be used with `iminuit <http://iminuit.github.com/iminuit/>`_. The
+intended to be used with `iminuit <http://iminuit.github.io/iminuit/>`_. The
 tool includes Binned/Unbinned Likelihood estimator, :math:`\chi^2` regression,
 Binned :math:`\chi^2` estimator and Simultaneous fit estimator. Normalization and
 Convolution with cache are also included. Various builtin function that's
 normally used in B physics is also provided.
 
+In a nutshell::
+
+    import numpy as np
+    from iminuit import Minuit
+    from probfit import UnbinnedLH, gaussian
+    data = np.random.randn(10000)
+    unbinned_likelihood = UnbinnedLH(gaussian, data)
+    fitter = Minuit(unbinned_likelihood, mean=0.1, sigma=1.1)
+    fitter.migrad()
+    unbinned_likelihood.draw(fitter)
+
 .. toctree::
     :maxdepth: 4
     :hidden:
-    
+
     api.rst
     recipe.rst
 
@@ -29,7 +40,8 @@ or get the latest development from github::
 Tutorial
 --------
 
-Tutorial is in the tutorial directory. You can `view it online <http://nbviewer.ipython.org/urls/raw.github.com/piti118/probfit/master/tutorial/tutorial.ipynb>`_ too.
+The tutorial consists of an IPython notebook in the tutorial directory.
+You can `view it online <http://nbviewer.ipython.org/urls/raw.github.com/iminuit/probfit/master/tutorial/tutorial.ipynb>`_ too.
 
 
 Commonly used API
@@ -110,3 +122,7 @@ You may find these functions useful in interactive environment.
     ~probfit.plotting.draw_pdf
     ~probfit.plotting.draw_compare_hist
 
+Cookbook
+--------
+
+Cookbook recipies are at :ref:`cookbook`.

--- a/doc/recipe.rst
+++ b/doc/recipe.rst
@@ -1,12 +1,17 @@
-How do I .....?
-===============
+.. _cookbook:
+
+Cookbook
+========
 
 Tell probfit to use my analytical integral
 ------------------------------------------
-probfit checks for method call integrate(bound, nint, *arg).
+
+probfit checks for a method ``integrate(bound, nint, *arg)``.
 If such method is available it calls that method to compute definite integral.
-If not it falls back to simpson3/8(cubic approximation).
+If not it falls back to simpson3/8 integration (cubic approximation).
+
 ::
+
     from probfit import integrate1d
     def line(x, m, c):
         return m*x+c

--- a/probfit/costfunc.pyx
+++ b/probfit/costfunc.pyx
@@ -143,7 +143,8 @@ cdef class UnbinnedLH:
         and data points *data*. Currently can only do 1D fit.
 
         .. math::
-            \\textrm{UnbinnedLH} = \sum_{x \in \\textrm{data}} - \log f(x, arg \ldots)
+            \\textrm{UnbinnedLH} = \sum_{x \in \\textrm{data}} - \log f(x, arg, \ldots)
+
         **Arguments**
 
             - **f** callable object. PDF that describe the data. The parameters
@@ -175,7 +176,8 @@ cdef class UnbinnedLH:
             - **extended_bound** Bound for calculating extended term.
               Default None(minimum and maximum of data will be used).
             - **extended_nint** number pieces to sum up as 
-              integral for extended Term(using simpson3/8). Default 100.
+              integral for extended term (using simpson3/8). Default 100.
+
         .. note::
             There is a notable lack of **sum_w2** for unbinned likelihood. I
             feel like the solutions are quite sketchy. There are multiple ways
@@ -252,9 +254,9 @@ cdef class UnbinnedLH:
               parameter errors are determined from **errors**. Default None.
 
             - **show_errbars** Show error bars. Default 'normal'
-               'normal' : error = sqrt( sum of weight )
-               'sumw2'  : error = sqrt( sum of weight**2 )
-                None : no errorbars (shown as a step histogram)
+                * 'normal' : error = sqrt( sum of weight )
+                * 'sumw2'  : error = sqrt( sum of weight**2 )
+                * None : no errorbars (shown as a step histogram)
         
         **Returns**
         

--- a/probfit/functor.pyx
+++ b/probfit/functor.pyx
@@ -220,7 +220,7 @@ cdef class Extended:
 cdef class AddPdf:
     """
     Directly add PDF without normalization nor factor.
-    Parmeters are merged by names.
+    Parameters are merged by names.
 
     ::
 
@@ -250,7 +250,7 @@ cdef class AddPdf:
 
                 factor[0]*f + factor[1]*g
 
-          Note that all argument for callable factors will be prefixed(if 
+          Note that all argument for callable factors will be prefixed (if 
           given) as opposed to skipping the first one for pdf list. If None
           is given, all factors are assume to be constant 1. Default None.
 

--- a/probfit/plotting.py
+++ b/probfit/plotting.py
@@ -26,8 +26,8 @@ def draw_simultaneous(self, minuit=None, args=None, errors=None, **kwds):
 
 def _get_args_and_errors(self, minuit=None, args=None, errors=None):
     """
-    consitent algorithm to get argument and errors
-    1) get it from minuit if minuit is avaialble
+    consistent algorithm to get argument and errors
+    1) get it from minuit if minuit is available
     2) if not get it from args and errors
     2.1) if args is dict parse it.
     3) if all else fail get it from self.last_arg
@@ -375,7 +375,7 @@ def draw_residual_blh(self, minuit=None, parmloc=(0.05, 0.95),
 
 def draw_compare(f, arg, edges, data, errors=None, ax=None, grid=True, normed=False, parts=False):
     """
-    this need to be rewritten
+    TODO: this needs to be rewritten
     """
     #arg is either map or tuple
     ax = plt.gca() if ax is None else ax
@@ -473,7 +473,7 @@ def draw_pdf_with_midpoints(f, arg, x, ax=None, scale=1.0, normed_pdf=False, **k
     return x, yf
 
 
-#draw comprison between function given args and data
+#draw comparison between function given args and data
 def draw_compare_hist(f, arg, data, bins=100, bound=None, ax=None, weights=None,
                       normed=False, use_w2=False, parts=False, grid=True):
     """
@@ -481,7 +481,7 @@ def draw_compare_hist(f, arg, data, bins=100, bound=None, ax=None, weights=None,
 
     ::
 
-        np.rannd(10000)
+        data = np.random.rand(10000)
         f = gaussian
         draw_compare_hist(f, {'mean':0,'sigma':1}, data, normed=True)
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     long_description=''.join(open('README.rst').readlines()[4:]),
     author='Piti Ongmongkolkul',
     author_email='piti118@gmail.com',
-    url='https://github.com/iminuit/probfit',
+    url='http://iminuit.github.io/probfit/',
     package_dir={'probfit': 'probfit'},
     packages=['probfit'],
     ext_modules=[costfunc, pdf, libstat, funcutil, functor],


### PR DESCRIPTION
Mostly typos, here's the real changes:
- For travis-ci, test with `iminuit/iminuit`, not `piti118/iminuit`
- Make the example in the README work and add the same example to the top-level docs page
- Add license info to README

Concerning the naming changes in the basic example ... I'll make a PR for an updated tutorial IPython notebook shortly where we can discuss this.
